### PR TITLE
Adjust links after repository transfer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,14 +24,14 @@ Features
 Features
 --------
 
-- Support Python 3.12 (`#469 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/469>`_)
+- Support Python 3.12 (`#469 <https://github.com/dbfixtures/pytest-rabbitmq/issues/469>`_)
 
 
 Miscellaneus
 ------------
 
-- Update code formatting with black 24.1 (`#424 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/424>`_)
-- Drop Pipfile.lock from repository - rely on a cached/artifacted one. (`#468 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/468>`_)
+- Update code formatting with black 24.1 (`#424 <https://github.com/dbfixtures/pytest-rabbitmq/issues/424>`_)
+- Drop Pipfile.lock from repository - rely on a cached/artifacted one. (`#468 <https://github.com/dbfixtures/pytest-rabbitmq/issues/468>`_)
 
 
 3.0.2 (2023-07-05)
@@ -40,8 +40,8 @@ Miscellaneus
 Bugfixes
 --------
 
-- Fixes logdir config option reading. (`#354 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/354>`_)
-- Fixes type hints for specifying ports in Rabbitmq startup process. (`#355 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/355>`_)
+- Fixes logdir config option reading. (`#354 <https://github.com/dbfixtures/pytest-rabbitmq/issues/354>`_)
+- Fixes type hints for specifying ports in Rabbitmq startup process. (`#355 <https://github.com/dbfixtures/pytest-rabbitmq/issues/355>`_)
 
 
 3.0.1 (2023-06-16)
@@ -50,7 +50,7 @@ Bugfixes
 Bugfixes
 --------
 
-- Fixed rabbitmq entrypoint (`#349 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/349>`_)
+- Fixed rabbitmq entrypoint (`#349 <https://github.com/dbfixtures/pytest-rabbitmq/issues/349>`_)
 
 
 3.0.0 (2023-06-15)
@@ -59,41 +59,41 @@ Bugfixes
 Breaking changes
 ----------------
 
-- Add your info here (`#313 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/313>`_)
-- Dropped support for Python 3.7 (`#324 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/324>`_)
+- Add your info here (`#313 <https://github.com/dbfixtures/pytest-rabbitmq/issues/313>`_)
+- Dropped support for Python 3.7 (`#324 <https://github.com/dbfixtures/pytest-rabbitmq/issues/324>`_)
 
 
 Deprecations
 ------------
 
-- Deprecate `rabbitmq_logsdir` and `--rabbitmq-logsdir` config options. (`#266 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/266>`_)
+- Deprecate `rabbitmq_logsdir` and `--rabbitmq-logsdir` config options. (`#266 <https://github.com/dbfixtures/pytest-rabbitmq/issues/266>`_)
 
 
 Features
 --------
 
 - Use `tmp_path_factory` instead of gettempdir() manually.
-  This will allow cleaning of a temporary files. (`#266 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/266>`_)
+  This will allow cleaning of a temporary files. (`#266 <https://github.com/dbfixtures/pytest-rabbitmq/issues/266>`_)
 - Define RABBITMQ_DIST_PORT for rabbitmq.
   Added `--rabbitmq-distribution-port` to commandline and `rabbitmq_distribution_port` to ini configuration options.
 
   This will help both with macos port number limit (as by default Rabbitmk adds 20000 to the Node port to determine the port), and the port being already used error.
 
-  This port has to be different that rabbitmq port. (`#317 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/317>`_)
-- Use towncrier to manage changelog. Require Pull Requests to contain proper newsfragment. (`#319 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/319>`_)
-- Introduce typing and run mypy checks (`#324 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/324>`_)
-- Official Python 3.11 support (`#329 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/329>`_)
+  This port has to be different that rabbitmq port. (`#317 <https://github.com/dbfixtures/pytest-rabbitmq/issues/317>`_)
+- Use towncrier to manage changelog. Require Pull Requests to contain proper newsfragment. (`#319 <https://github.com/dbfixtures/pytest-rabbitmq/issues/319>`_)
+- Introduce typing and run mypy checks (`#324 <https://github.com/dbfixtures/pytest-rabbitmq/issues/324>`_)
+- Official Python 3.11 support (`#329 <https://github.com/dbfixtures/pytest-rabbitmq/issues/329>`_)
 
 
 Miscellaneus
 ------------
 
-- Upadte test pipeline to install fresh rabbitmq from apt. (`#280 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/280>`_)
-- Migrate dev dependency management to pipfile (`#320 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/320>`_)
-- Migrate automerge workflow to shared one with merger app (`#321 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/321>`_)
-- Replace pycodestyle and pydocstyle with ruff. (`#322 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/322>`_)
-- Move package configuration to pyproject.toml (`#323 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/323>`_)
-- Migrate to tbump to manage package versions (`#340 <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/340>`_)
+- Upadte test pipeline to install fresh rabbitmq from apt. (`#280 <https://github.com/dbfixtures/pytest-rabbitmq/issues/280>`_)
+- Migrate dev dependency management to pipfile (`#320 <https://github.com/dbfixtures/pytest-rabbitmq/issues/320>`_)
+- Migrate automerge workflow to shared one with merger app (`#321 <https://github.com/dbfixtures/pytest-rabbitmq/issues/321>`_)
+- Replace pycodestyle and pydocstyle with ruff. (`#322 <https://github.com/dbfixtures/pytest-rabbitmq/issues/322>`_)
+- Move package configuration to pyproject.toml (`#323 <https://github.com/dbfixtures/pytest-rabbitmq/issues/323>`_)
+- Migrate to tbump to manage package versions (`#340 <https://github.com/dbfixtures/pytest-rabbitmq/issues/340>`_)
 
 
 2.2.1

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://raw.githubusercontent.com/ClearcodeHQ/pytest-rabbitmq/master/logo.png
+.. image:: https://raw.githubusercontent.com/dbfixtures/pytest-rabbitmq/master/logo.png
     :width: 100px
     :height: 100px
     
@@ -24,12 +24,12 @@ pytest-rabbitmq
 Package status
 --------------
 
-.. image:: https://travis-ci.org/ClearcodeHQ/pytest-rabbitmq.svg?branch=v2.2.1
-    :target: https://travis-ci.org/ClearcodeHQ/pytest-rabbitmq
+.. image:: https://travis-ci.org/dbfixtures/pytest-rabbitmq.svg?branch=v2.2.1
+    :target: https://travis-ci.org/dbfixtures/pytest-rabbitmq
     :alt: Tests
 
-.. image:: https://coveralls.io/repos/ClearcodeHQ/pytest-rabbitmq/badge.png?branch=v2.2.1
-    :target: https://coveralls.io/r/ClearcodeHQ/pytest-rabbitmq?branch=v2.2.1
+.. image:: https://coveralls.io/repos/dbfixtures/pytest-rabbitmq/badge.png?branch=v2.2.1
+    :target: https://coveralls.io/r/dbfixtures/pytest-rabbitmq?branch=v2.2.1
     :alt: Coverage Status
 
 What is this?
@@ -150,4 +150,4 @@ Example usage:
 Package resources
 -----------------
 
-* Bug tracker: https://github.com/ClearcodeHQ/pytest-rabbitmq/issues
+* Bug tracker: https://github.com/dbfixtures/pytest-rabbitmq/issues

--- a/newsfragments/+5fbbfb1e.misc.rst
+++ b/newsfragments/+5fbbfb1e.misc.rst
@@ -1,0 +1,1 @@
+Adjust links after repository transfer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dependencies = [
 requires-python = ">= 3.9"
 
 [project.urls]
-"Source" = "https://github.com/ClearcodeHQ/pytest-rabbitmq"
-"Bug Tracker" = "https://github.com/ClearcodeHQ/pytest-rabbitmq/issues"
-"Changelog" = "https://github.com/ClearcodeHQ/pytest-rabbitmq/blob/v3.1.1/CHANGES.rst"
+"Source" = "https://github.com/dbfixtures/pytest-rabbitmq"
+"Bug Tracker" = "https://github.com/dbfixtures/pytest-rabbitmq/issues"
+"Changelog" = "https://github.com/dbfixtures/pytest-rabbitmq/blob/v3.1.1/CHANGES.rst"
 
 [project.entry-points."pytest11"]
 pytest_rabbitmq = "pytest_rabbitmq.plugin"
@@ -80,7 +80,7 @@ select = [
 directory = "newsfragments"
 single_file=true
 filename="CHANGES.rst"
-issue_format="`#{issue} <https://github.com/ClearcodeHQ/pytest-rabbitmq/issues/{issue}>`_"
+issue_format="`#{issue} <https://github.com/dbfixtures/pytest-rabbitmq/issues/{issue}>`_"
 
 [tool.towncrier.fragment.feature]
 name = "Features"
@@ -142,7 +142,7 @@ search = 'version = "{current_version}"'
 
 [[tool.tbump.file]]
 src = "pyproject.toml"
-search = '"Changelog" = "https://github.com/ClearcodeHQ/pytest-rabbitmq/blob/v{current_version}/CHANGES.rst"'
+search = '"Changelog" = "https://github.com/dbfixtures/pytest-rabbitmq/blob/v{current_version}/CHANGES.rst"'
 
 # You can specify a list of commands to
 # run after the files have been patched


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number